### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/nstarman/mvgkde/security/code-scanning/1](https://github.com/nstarman/mvgkde/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token scopes.  
Best single fix without changing behavior: set minimal baseline permissions at workflow root:

- `contents: read` (needed by `actions/checkout`)
- `packages: read` (safe/read-only baseline often needed by package registries; aligns with GitHub recommendation)

Insert this block after the `on:` trigger section and before `concurrency:`. This preserves existing job logic and applies uniformly across current/future jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
